### PR TITLE
Add pickerExpand and pickerCollapse custom event dispatchers

### DIFF
--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -174,6 +174,14 @@
 
 	applyPreset('full')
 
+	function onPickerExpand (e) {
+		console.log('Picker Expand', e.detail)
+	}
+
+	function onPickerCollapse (e) {
+		console.log('Picker Collapse', e.detail)
+	}
+
 	$: {
 		if (color.isDark()) {
 			document.body.classList.remove('dark')
@@ -207,6 +215,9 @@
 					background={background}
 
 					collapse={collapse}
+					on:pickerExpand={onPickerExpand}
+					on:pickerCollapse={onPickerCollapse}
+
 					handleWidth={handleWidth}
 					handleHeight={handleHeight}
 

--- a/src/ColorPicker.svelte
+++ b/src/ColorPicker.svelte
@@ -1,4 +1,6 @@
 <script>
+	import { createEventDispatcher } from 'svelte'
+
 	import Color from './color'
 	import { dimensions, getDimension } from './dimensions.js'
 
@@ -8,6 +10,8 @@
 	import HexInput from './HexInput.svelte'
 
 	export let color = Color.hex('#ff9900')
+
+	const dispatch = createEventDispatcher();
 
 	$: {
 			if (typeof color === 'string') {
@@ -61,17 +65,26 @@
 
 	$: sliderWidth = matrixWidth - (selectDimensions ? 25 : 0) - (showLabels ? 25 : 0) - (showNumeric ? 65 : 0)
 	$: textboxWidth = matrixWidth - (showLabels ? 50 : 0)
+
+	const expandPicker = () => {
+		collapsed = false
+		dispatch('pickerExpand', { collapsed, color })
+	}
+	const collapsePicker = () => {
+		collapsed = true
+		dispatch('pickerCollapse', { collapsed, color })
+	}
 </script>
 
 <div class='color-picker {collapse ? "collapse" : ""}'>
 
 
 	{#if collapse && !collapsed}
-		<div class='color-picker-background' on:click={() => collapsed = true}/>
+		<div class='color-picker-background' on:click={collapsePicker}/>
 	{/if}
 
 	{#if collapse}
-	<div class="color-picker-handle" style='width: {handleWidth}px; height: {handleHeight}px; background: {color.toHex()};' on:click={() => collapsed = false}></div>
+	<div class="color-picker-handle" style='width: {handleWidth}px; height: {handleHeight}px; background: {color.toHex()};' on:click={expandPicker}></div>
 	{/if}
 
 	<div class='color-picker-controls {collapse && collapsed ? "collapsed" : ""}' style="background: {background};">


### PR DESCRIPTION
## What does this do?

Adds `on:pickerExpand` and `on:pickerCollapse` custom events to know when the picker is opened and closed when using with collapse mode.

Both events will receive event details containing the `collapsed` state and picked `color`.

### Example:
```html
<script>
  import { Color, ColorPicker } from 'svelte-colorpick';

  let color = Color.hex('#ffff00');

  const pickerCollapse = evt => console.log('Collapsed:', evt.detail);
  const pickerExpand = evt => console.log('Expanded:', evt.detail);
</script>

<ColorPicker
  bind:color
  collapse="{true}"
  on:pickerCollapse="{pickerCollapse}"
  on:pickerExpand="{pickerExpand}"
  showSliders="{{ 'hsl.h': true }}"
/>
```

